### PR TITLE
fix: Add missing forward slash to markAllRead url

### DIFF
--- a/packages/stream_chat/lib/src/core/api/channel_api.dart
+++ b/packages/stream_chat/lib/src/core/api/channel_api.dart
@@ -84,7 +84,7 @@ class ChannelApi {
 
   /// Mark all channels for this user as read
   Future<EmptyResponse> markAllRead() async {
-    final response = await _client.post('channels/read');
+    final response = await _client.post('/channels/read');
     return EmptyResponse.fromJson(response.data);
   }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Running latest GetStream SDK (from version 2.0.0) calling `channel.markAllRead()` will throw an error similar to this:

```bash
I/flutter (10572): ----------------FIREBASE CRASHLYTICS----------------
I/flutter (10572): StreamChatNetworkError(code: -1, message: SocketException: Failed host lookup: 'chat-us-east-1.stream-io-api.comchannels' (OS Error: No address associated with hostname, errno = 7))
I/flutter (10572): #0      StreamHttpClient.post (package:stream_chat/src/core/http/stream_http_client.dart:158:7)
I/flutter (10572): <asynchronous suspension>
I/flutter (10572): #1      ChannelApi.markAllRead (package:stream_chat/src/core/api/channel_api.dart:87:22)
I/flutter (10572): <asynchronous suspension>
I/flutter (10572): ----------------------------------------------------
```

Adding a `/` to the front of the called URL will resolve this - I've done this locally and it works.